### PR TITLE
'File Skip' support

### DIFF
--- a/AssetsAutoCompressComponent.php
+++ b/AssetsAutoCompressComponent.php
@@ -147,6 +147,13 @@ class AssetsAutoCompressComponent extends Component implements BootstrapInterfac
 
 
     /**
+     * Skip specific filenames.
+     * @var array
+     */
+    public $skip = [];
+
+
+    /**
      * @param \yii\base\Application $app
      */
     public function bootstrap($app)
@@ -386,6 +393,13 @@ JS
             $resultFiles    = [];
             foreach ($files as $fileCode => $fileTag)
             {
+                
+                if(in_array(array_pop(explode('/', $fileCode)), $this->skip))
+                {
+                    $resultFiles[$fileCode] = $fileTag;
+                    continue;
+                }
+
                 if (Url::isRelative($fileCode))
                 {
                     $contentFile = $this->fileGetContents( Url::to(\Yii::getAlias($fileCode), true) );

--- a/AssetsAutoCompressComponent.php
+++ b/AssetsAutoCompressComponent.php
@@ -369,6 +369,12 @@ JS
 
             foreach ($files as $fileCode => $fileTag)
             {
+                if(in_array(array_pop(explode('/', $fileCode)), $this->skip))
+                {
+                    $resultFiles[$fileCode] = $fileTag;
+                    continue;
+                }
+
                 if (!Url::isRelative($fileCode))
                 {
                     $resultFiles[$fileCode] = $fileTag;
@@ -480,6 +486,12 @@ JS
 
             foreach ($files as $fileCode => $fileTag)
             {
+                if(in_array(array_pop(explode('/', $fileCode)), $this->skip))
+                {
+                    $resultFiles[$fileCode] = $fileTag;
+                    continue;
+                }
+
                 if (Url::isRelative($fileCode))
                 {
 
@@ -505,6 +517,12 @@ JS
             $resultFiles    = [];
             foreach ($files as $fileCode => $fileTag)
             {
+                if(in_array(array_pop(explode('/', $fileCode)), $this->skip))
+                {
+                    $resultFiles[$fileCode] = $fileTag;
+                    continue;
+                }
+
                 if (Url::isRelative($fileCode))
                 {
                     $contentTmp         = trim($this->fileGetContents( Url::to(\Yii::getAlias($fileCode), true) ));


### PR DESCRIPTION
Added support for the ability to skip specific files and have them render normally regardless of the assets compression.

Example:

```
'assetsAutoCompress' => [
    'class' => '\skeeks\yii2\assetsAuto\AssetsAutoCompressComponent',
    'enabled' => TRUE,
    'skip' => [
        'scriptname.js',
    ]
],
```

And the end result on the page:

```
<script src="/assets/d905b4ac/scriptname.js"></script>
<script src="/assets/js-compress/6dc4a89b3dc86323accc70fe63033e53.js?v=1479571730"></script>
```

I needed it for my own project so I went ahead and wrote it. Should work with all JavaScript and CSS files, assuming they have unique filenames.