### PR TITLE
Return file contents only if file exists

### DIFF
--- a/AssetsAutoCompressComponent.php
+++ b/AssetsAutoCompressComponent.php
@@ -622,7 +622,7 @@ JS
             }
 
             $info = curl_getinfo($ch);
-            if (ArrayHelper::getValue($info, 'http_code') == 404)
+            if (isset($info['http_code']) && !ArrayHelper::isIn(ArrayHelper::getValue($info, 'http_code'), [200])) {
             {
                 curl_close($ch);
                 throw new \Exception("File not found: {$file}");


### PR DESCRIPTION
There's few 400 and 500 errors, why don't use just 200 response to confirm that file exists?