### PR TITLE
Fixed building path to files for Yii version >=2.0.39 with non-empty BaseUrl

### DIFF
--- a/src/AssetsAutoCompressComponent.php
+++ b/src/AssetsAutoCompressComponent.php
@@ -411,6 +411,7 @@ JS
             if (!$this->jsFileRemouteCompile) {
                 foreach ($files as $fileCode => $fileTag) {
                     if (!Url::isRelative($fileCode)) {
+                        $fileCode = $this->getFileCode($fileCode);
                         $resultFiles[$fileCode] = $fileTag;
                     }
                 }
@@ -429,6 +430,7 @@ JS
             foreach ($files as $fileCode => $fileTag) {
                 if (Url::isRelative($fileCode)) {
                     if ($pos = strpos($fileCode, "?")) {
+                        $fileCode = $this->getFileCode($fileCode);
                         $fileCode = substr($fileCode, 0, $pos);
                     }
 
@@ -600,6 +602,7 @@ JS
             if (!$this->cssFileRemouteCompile) {
                 foreach ($files as $fileCode => $fileTag) {
                     if (!Url::isRelative($fileCode)) {
+                        $fileCode = $this->getFileCode($fileCode);
                         $resultFiles[$fileCode] = $fileTag;
                     }
                 }
@@ -616,6 +619,7 @@ JS
             $resultFiles = [];
             foreach ($files as $fileCode => $fileTag) {
                 if (Url::isRelative($fileCode)) {
+                    $fileCode = $this->getFileCode($fileCode);
                     $fileCodeLocal = $fileCode;
                     if ($pos = strpos($fileCode, "?")) {
                         $fileCodeLocal = substr($fileCodeLocal, 0, $pos);
@@ -726,6 +730,18 @@ JS
         return $html;
     }
 
+    /**
+     * Fix for Yii version 2.0.39 and higher if the project has a non-empty baseUrl
+     *
+     * @param  string $fileCode Path to file
+     *
+     * @return string
+     * @link   https://github.com/yiisoft/yii2/issues/18414
+     */
+    protected function getFileCode($fileCode)
+    {
+        return !empty(\Yii::$app->request->getBaseUrl()) ? str_replace(\Yii::$app->request->getBaseUrl(), '', $fileCode) : $fileCode;
+    }
 
     /**
      * @param $value


### PR DESCRIPTION
The issue was discussed here https://github.com/yiisoft/yii2/issues/18414.

In version 2.0.39, there was a problem with projects with non-empty `BaseUrl` and `appendTimestamp` included. In this case, when the list of files (.css and .js) was compiled, the path to the file was built incorrectly when the file modification time was received. `BaseUrl` was contained in both `@webroot` mask and relative file path. Those, it turned out something like this `G: /XAMPP7/htdocs/subdomain/site/web/subdomain/site/css/custom.css` instead of the prescribed `G: /XAMPP7/htdocs/subdomain/site/web/css/custom.css`. There it was fixed by removing `BaseUrl` in the relative path.

Here I found a similar problem: no compiled files were generated on projects with non-empty `BaseUrl`. The script that bypassed the .css and .js lists could not get any of the files, since paths contained doubled `BaseUrl`.

Fix #54