### PR TITLE
Fixed CSS code processing and minification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
 		"yiisoft/yii2-httpclient": "^2",
 		"tedivm/jshrink": "^1.3.0",
 		"natxet/cssmin": "^3.0.6",
-		"mrclay/minify": "^3.0.3"
+		"mrclay/minify": "^3.0.3",
+        "matthiasmullie/minify": "^1.3"
 	},
     "autoload": {
         "psr-4": {

--- a/src/AssetsAutoCompressComponent.php
+++ b/src/AssetsAutoCompressComponent.php
@@ -411,6 +411,7 @@ JS
             if (!$this->jsFileRemouteCompile) {
                 foreach ($files as $fileCode => $fileTag) {
                     if (!Url::isRelative($fileCode)) {
+                        $fileCode = $this->getFileCode($fileCode);
                         $resultFiles[$fileCode] = $fileTag;
                     }
                 }
@@ -429,6 +430,7 @@ JS
             foreach ($files as $fileCode => $fileTag) {
                 if (Url::isRelative($fileCode)) {
                     if ($pos = strpos($fileCode, "?")) {
+                        $fileCode = $this->getFileCode($fileCode);
                         $fileCode = substr($fileCode, 0, $pos);
                     }
 
@@ -600,6 +602,7 @@ JS
             if (!$this->cssFileRemouteCompile) {
                 foreach ($files as $fileCode => $fileTag) {
                     if (!Url::isRelative($fileCode)) {
+                        $fileCode = $this->getFileCode($fileCode);
                         $resultFiles[$fileCode] = $fileTag;
                     }
                 }
@@ -616,6 +619,7 @@ JS
             $resultFiles = [];
             foreach ($files as $fileCode => $fileTag) {
                 if (Url::isRelative($fileCode)) {
+                    $fileCode = $this->getFileCode($fileCode);
                     $fileCodeLocal = $fileCode;
                     if ($pos = strpos($fileCode, "?")) {
                         $fileCodeLocal = substr($fileCodeLocal, 0, $pos);
@@ -726,6 +730,18 @@ JS
         return $html;
     }
 
+    /**
+     * Fix for Yii version 2.0.39 and higher if the project has a non-empty baseUrl
+     *
+     * @param  string $fileCode Path to file
+     *
+     * @return string
+     * @link   https://github.com/yiisoft/yii2/issues/18414
+     */
+    protected function getFileCode($fileCode)
+    {
+        return !empty(\Yii::$app->request->getBaseUrl()) ? str_replace(\Yii::$app->request->getBaseUrl(), '', $fileCode) : $fileCode;
+    }
 
     /**
      * @param $value


### PR DESCRIPTION
The [mrclay/minify](https://github.com/mrclay/minify) extension did not handle relative paths correctly, in particular those with `../` and `./`. It has written its own function that adjusts paths based on the initial location of the file and the final one.

**An example of incorrect path handling**
New path: `/var/www/site/web/assets/css-compress`
Old path: `/var/www/site/web/css`

In CSS codes, we have the path `../images/image1.png`. After processing it should look like this `../../images/image1.png`, but instead [mrclay/minify](https://github.com/mrclay/minify) makes it like this.

------

The [natxet/cssmin](https://github.com/natxet/CssMin) extension does not correctly process already minified code, so it was replaced with the [matthiasmullie/minify](https://github.com/matthiasmullie/minify) extension.

**An example of incorrect code processing**
Input has line `@media(max-width:767px){.table-responsive ...`, and the output is `@media max-width:767px){.table-responsive ...`.

Fix #43