### PR TITLE
Update AssetsAutoCompressComponent.php

### DIFF
--- a/src/AssetsAutoCompressComponent.php
+++ b/src/AssetsAutoCompressComponent.php
@@ -638,7 +638,7 @@ JS
                     $prependRelativePath = implode("/", $fileCodeTmp)."/";
 
                     //print_r($prependRelativePath);die;
-                    $contentTmp = \Minify_CSS::minify($contentTmp, [
+                    $contentTmp = \Minify_CSSmin::minify($contentTmp, [
                         "prependRelativePath" => $prependRelativePath,
 
                         'compress'         => true,


### PR DESCRIPTION
Minify_CSS is deprecated, Minify_CSS has been replaced by Minify_CSSmin. 

Also, in the old version, there are problems with compilation, expressions with + do not contain spaces. For example: 
```css
font-size:clamp(1.313rem,0.5rem+2.5vw,2.75rem)  // incorrect value
```